### PR TITLE
rename to OAuthenticator::RackAuthenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ documentation for the module `OAuthenticator::ConfigMethods`, which defines stub
 each recognized method, with method documentation relating to your implementation.
 
 A simple, contrived example follows, which approximately resembles what you might implement. It is not useful 
-on its own but will be used in following examples for usage of Middleware and SignedRequest. 
+on its own but will be used in following examples for usage of RackAuthenticator and SignedRequest. 
 
 ```ruby
 require 'oauthenticator'
@@ -119,25 +119,25 @@ end
 You may also find it enlightening to peruse `test/test_config_methods.rb`, which sets up some very simple 
 storage in memory, and defines a module of config methods which are used through the tests. 
 
-### OAuthenticator::Middleware
+### OAuthenticator::RackAuthenticator
 
-The middleware is used by passing the above-mentioned module on the `:config_methods` key to  initialize the 
-middleware:
+The RackAuthenticator middleware is used by passing the above-mentioned module on the `:config_methods` key to 
+initialize the middleware:
 
 ```ruby
 # config.ru
 
-use OAuthenticator::Middleware, :config_methods => AwesomeOAuthConfig
+use OAuthenticator::RackAuthenticator, :config_methods => AwesomeOAuthConfig
 run proc { |env| [200, {'Content-Type' => 'text/plain'}, ['access granted!']] }
 ```
 
 The authentication can also be bypassed with a proc on the `:bypass` key; see the documentation for 
-`OAuthenticator::Middleware` for the details of that. 
+`OAuthenticator::RackAuthenticator` for the details of that. 
 
 ### OAuthenticator::SignedRequest
 
-The OAuthenticator::SignedRequest class may be used independently of the middleware, though it must also be 
-passed your module of config methods to include. It is used like:
+The OAuthenticator::SignedRequest class may be used independently of the RackAuthenticator middleware, though 
+it must also be passed your module of config methods to include. It is used like:
 
 ```ruby
 OAuthenticator::SignedRequest.including_config(AwesomeOAuthConfig).new(request_attrs)

--- a/lib/oauthenticator.rb
+++ b/lib/oauthenticator.rb
@@ -1,4 +1,4 @@
 require 'oauthenticator/version'
-require 'oauthenticator/middleware'
 require 'oauthenticator/signed_request'
 require 'oauthenticator/signable_request'
+require 'oauthenticator/rack_authenticator'

--- a/lib/oauthenticator/rack_authenticator.rb
+++ b/lib/oauthenticator/rack_authenticator.rb
@@ -10,7 +10,7 @@ module OAuthenticator
   # structured like rails / ActiveResource:
   #
   #     {'errors': {'attribute1': ['messageA', 'messageB'], 'attribute2': ['messageC']}}
-  class Middleware
+  class RackAuthenticator
     # options:
     #
     # - `:bypass` - a proc which will be called with a Rack::Request, which must have a boolean result. 

--- a/lib/oauthenticator/signed_request.rb
+++ b/lib/oauthenticator/signed_request.rb
@@ -233,10 +233,10 @@ module OAuthenticator
     # raise a nice error message for a method that needs to be implemented on a module of config methods 
     def config_method_not_implemented
       caller_name = caller[0].match(%r(in `(.*?)'))[1]
-      using_middleware = caller.any? { |l| l =~ %r(oauthenticator/middleware.rb:.*`call') }
+      using_middleware = caller.any? { |l| l =~ %r(oauthenticator/rack_authenticator.rb:.*`call') }
       message = "method \##{caller_name} must be implemented on a module of oauth config methods, which is " + begin
         if using_middleware
-          "passed to OAuthenticator::Middleware using the option :config_methods."
+          "passed to OAuthenticator::RackAuthenticator using the option :config_methods."
         else
           "included in a subclass of OAuthenticator::SignedRequest, typically by passing it to OAuthenticator::SignedRequest.including_config(your_module)."
         end

--- a/test/config_methods_test.rb
+++ b/test/config_methods_test.rb
@@ -17,15 +17,15 @@ describe OAuthenticator::SignedRequest do
       assert called
     end
   end
-  it "complains when a method without a default is not implemented, using middleware" do
+  it "complains when a method without a default is not implemented, using RackAuthenticator" do
     exc = assert_raises(NotImplementedError) do
-      OAuthenticator::Middleware.new(proc {}, {:config_methods => Module.new}).call({'HTTP_AUTHORIZATION' => %q(OAuth oauth_timestamp="1")})
+      OAuthenticator::RackAuthenticator.new(proc {}, {:config_methods => Module.new}).call({'HTTP_AUTHORIZATION' => %q(OAuth oauth_timestamp="1")})
     end
-    assert_match /passed to OAuthenticator::Middleware using the option :config_methods./, exc.message
+    assert_match /passed to OAuthenticator::RackAuthenticator using the option :config_methods./, exc.message
   end
-  it "complains middleware is not given config methods" do
+  it "complains RackAuthenticator is not given config methods" do
     assert_raises(ArgumentError) do
-      OAuthenticator::Middleware.new(proc {})
+      OAuthenticator::RackAuthenticator.new(proc {})
     end
   end
   it 'uses timestamp_valid_period if that is implemented but timestamp_valid_past or timestamp_valid_future is not' do

--- a/test/test_config_methods.rb
+++ b/test/test_config_methods.rb
@@ -46,7 +46,7 @@ module TestHelperMethods
   end
 
   let(:simpleapp) { proc { |env| [200, {'Content-Type' => 'text/plain; charset=UTF-8'}, ['☺']] } }
-  let(:oapp) { OAuthenticator::Middleware.new(simpleapp, :config_methods => OAuthenticatorTestConfigMethods) }
+  let(:oapp) { OAuthenticator::RackAuthenticator.new(simpleapp, :config_methods => OAuthenticatorTestConfigMethods) }
 
   let(:consumer) do
     {:key => "test_client_app_key", :secret => "test_client_app_secret"}.tap do |consumer|


### PR DESCRIPTION
rename OAuthenticator::Middleware to OAuthenticator::RackAuthenticator. much better, less generic name. also 'middleware' is ambiguous now that faraday is in the mix; both rack and faraday had different middlewares. 
