### PR TITLE
NonceUsedError

### DIFF
--- a/lib/oauthenticator/parse_authorization.rb
+++ b/lib/oauthenticator/parse_authorization.rb
@@ -4,7 +4,7 @@ module OAuthenticator
   class Error < StandardError
     # @param message [String]
     # @param errors [Hash<String, Array<String>>]
-    def initialize(message, errors=nil)
+    def initialize(message=nil, errors=nil)
       super(message)
       @errors = errors
     end

--- a/lib/oauthenticator/signed_request.rb
+++ b/lib/oauthenticator/signed_request.rb
@@ -2,6 +2,10 @@ require 'oauthenticator/signable_request'
 require 'oauthenticator/parse_authorization'
 
 module OAuthenticator
+  # an error which is to be raised when an attempt is made to use a nonce which has already been used.
+  class NonceUsedError < Error
+  end
+
   # this class represents an OAuth signed request. its primary user-facing method is {#errors}, which returns 
   # nil if the request is valid and authentic, or a helpful object of error messages describing what was 
   # invalid if not. 
@@ -215,7 +219,12 @@ module OAuthenticator
           throw(:errors, {'Authorization oauth_signature' => ['is invalid']})
         end
 
-        use_nonce!
+        begin
+          use_nonce!
+        rescue NonceUsedError
+          throw(:errors, {'Authorization oauth_nonce' => ['has already been used']})
+        end
+
         nil
       end
     end

--- a/test/test_config_methods.rb
+++ b/test/test_config_methods.rb
@@ -18,7 +18,12 @@ module OAuthenticatorTestConfigMethods
   end
 
   def use_nonce!
-    OAuthenticatorTestConfigMethods.nonces << nonce
+    if OAuthenticatorTestConfigMethods.nonces.include?(nonce)
+      # checking the same thing as #nonce_used? lets #nonce_used? be overridden to return false and things still work 
+      raise OAuthenticator::NonceUsedError
+    else
+      OAuthenticatorTestConfigMethods.nonces << nonce
+    end
   end
 
   def timestamp_valid_period


### PR DESCRIPTION
add OAuthenticator::NonceUsedError to address potential race condition between #nonce_used? and #use_nonce!

@edan
