### PR TITLE
remove json restriction

### DIFF
--- a/oauthenticator.gemspec
+++ b/oauthenticator.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'rack', '>= 1.4', '< 2.1'
-  spec.add_runtime_dependency 'json', '~> 1.8'
+  spec.add_runtime_dependency 'json'
   spec.add_runtime_dependency 'faraday', '~> 0.9'
   spec.add_runtime_dependency 'addressable', '~> 2.3'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
open-ended dependencies are bad, but really any version of json is going to be fine.

ruby 2.4.0 needs newer json.