### PR TITLE
Note that for RSA-SHA1, token secret is the RSA certificate contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ connection.get '/path'
 ```
 
 Note that `:url_encoded` is only included to illustrate that other middleware should all go before 
-`:oauthenticator_signer`; the use of `:url_encoded` is not related to OAuthenticator. 
+`:oauthenticator_signer`; the use of `:url_encoded` is not related to OAuthenticator.
+
+Note that for the RSA-SHA1 signature method, the token secret is the contents of the RSA certificate
+used for signing the requests.
 
 ### Any other HTTP library
 


### PR DESCRIPTION
Thank you for this library, I was able to implement oauth1.0a for Jira using it with faraday quite painlessly. The only thing I had to look up in the source was how to provide my RSA certificate, which turned out to be the consumer secret. This PR proposes adding a note to the readme to this effect to assist future users.